### PR TITLE
doc: OutputMode improved intellisense

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -18,10 +18,14 @@ function splitCommand(command: string): string[] {
 }
 
 export enum OutputMode {
-  None = 0, // no output, just run the command
-  StdOut, // dump the output to stdout
-  Capture, // capture the output and return it
-  Tee, // both dump and capture the output
+  /** no output, just run the command */
+  None = 0,
+  /** dump the output to stdout */
+  StdOut,
+  /** capture the output and return it */
+  Capture,
+  /** both dump and capture the output */
+  Tee,
 }
 
 export interface IExecStatus {


### PR DESCRIPTION
Moves the normal comments on `OutputMode` to tsdoc style comment blocks, so IDEs can infer documentation on these symbols.

![image](https://user-images.githubusercontent.com/7970987/90355622-ec82fb80-e01a-11ea-954f-525a35f2fd21.png)
