### PR TITLE
Formatting and syntax highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,38 +9,47 @@ For example:
 
 ## Run a simple external command and display the output
 To run an external command and display the output:
-```
+
+```ts
 import { exec } from "https://deno.land/x/exec/mod.ts";
+
 await exec('echo Hello World');
 ```
+
 Big deal.  But lets say you're running a docker swarm and want to scale a process to 3 nodes:
-```
+
+```ts
 import { exec } from "https://deno.land/x/exec/mod.ts";
 
 await exec('ssh foo@xxx.xxx.com "docker service scale some_service=3"');
 await exec('ssh foo@xxx.xxx.com "docker service ls"');
-
 ```
 
 ## Run commands in "follow" mode
 Some commands like `tail -f` or `docker logs -f` have the ability to run in "follow" mode.  In this mode,
 they continue to run while data is appended to stdout over time.  You can do this with:
-```
+
+```ts
 import { exec } from "https://deno.land/x/exec/mod.ts";
+
 await exec('docker service logs someapi -f');
 ```
+
 In this case, the connection to stdout will remain open until you terminate the function.
 
 ## Capture the output of an external command
 Sometimes you need to capture the output of a command.  For example, I do this to get git log checksums:
-```
+
+```ts
 import { exec } from "https://deno.land/x/exec/mod.ts";
+
 let response = await exec('git log -1 --format=%H', {output: OutputMode.Capture});
 ```
 
 With the response object in hand, you can grab the status code and any data that would have been
 written to stdout.  The response is of type IExecResponse and is shaped as follows:
-```
+
+```ts
 export interface IExecStatus {
   code: number;
   success: boolean;
@@ -51,17 +60,18 @@ export interface IExecResponse {
   output: string;
 }
 ```
+
 ## Does piping work?
 
 When you think of piping in a case list this, you often think of something like
 
-```
+```ts
 cat test.ts | sed -e 's/^/prefix/'
 ```
 
 In that case, piping is actually done by the shell, so `exec` cannot do that itself. However, it can do this, which accomplishes the same thing:
 
-```
+```ts
 let r = await exec(
   `bash -c "cat test.ts | sed -e 's/^/prefix/'"`,
 );
@@ -74,12 +84,12 @@ If you want to implement your own piping within the app, you can (currently) cap
 ## Command Sequences
 In addition to running commands, you can run a sequence of commands in one call.  For example:
 
-```
+```ts
 let response = await execSequence([
-      "echo Hello World",
-      "ls -l",
-      "cat helloworld.txt",
-    ], { output: OutputMode.None, continueOnError: false });
+    "echo Hello World",
+    "ls -l",
+    "cat helloworld.txt",
+  ], { output: OutputMode.None, continueOnError: false });
 ```
 
 In this case, the commands are simply run one after the other, in sequence.  The OutputMode is applied to 


### PR DESCRIPTION
## Changes

- Set all code blocks to `ts` for TypeScript syntax highlighting
- Consistently format all example code blocks with 2-spaces