### PR TITLE
fix: generate uuid by v1

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { v4 } from "https://deno.land/std/uuid/mod.ts";
+import { v1 } from "https://deno.land/std/uuid/mod.ts";
 
 function splitCommand(command: string): string[] {
   var myRegexp = /[^\s"]+|"([^"]*)"/gi;
@@ -52,7 +52,7 @@ export const exec = async (
 
   let uuid = "";
   if (options.verbose) {
-    uuid = v4.generate();
+    uuid = "" + v1.generate();
     console.log(``);
     console.log(`Exec Context: ${uuid}`);
     console.log(`    Exec Options: `, options);


### PR DESCRIPTION
v4.generate is deprecated and deleted by https://github.com/denoland/deno_std/pull/2720